### PR TITLE
arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
-FROM debian:9
+FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y apt-utils && \
-    apt-get install -y build-essential debhelper git && \
-    echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && apt-get install -y postgresql-common postgresql-server-dev-all
+RUN dpkg --add-architecture arm64 && \
+    apt-get update && apt-get install -y apt-utils aptitude && \
+    apt-get install -y build-essential crossbuild-essential-arm64 debhelper git && \
+    echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && apt-get update && \
+    aptitude install -y postgresql-client-10:arm64 postgresql-common:arm64 postgresql-server-dev-10:arm64 && \
+    mv /usr/lib/postgresql/10/bin/pg_config /usr/lib/postgresql/10/bin/pg_config.alien && \
+    apt-get download postgresql-server-dev-all:arm64 && \
+    dpkg-deb -R postgresql-server-dev-all* psda/ && \
+    grep -v '^Depends: .*' psda/DEBIAN/control > psda/DEBIAN/control_new && \
+    mv psda/DEBIAN/control_new psda/DEBIAN/control && \
+    dpkg-deb -b psda/ && \
+    dpkg -i psda.deb
+
+COPY pg_config.minimal /usr/lib/postgresql/10/bin/pg_config
 
 WORKDIR "/mnt/build"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ node ('docker') {
         }
     }
     stage ('Build debian packages') {
-        sh "docker run -v $WORKSPACE:/mnt --rm ${img.id} dpkg-buildpackage -b";
+        sh "docker run -v $WORKSPACE:/mnt --rm ${img.id} CC=aarch64-linux-gnu-gcc CONFIG_SITE=/etc/dpkg-cross/cross-config.arm64 DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -aarm64 -Pcross,nocheck -b"
         sh "ls ${WORKSPACE}; ls ${WORKSPACE}/";
     }
     dir ("${WORKSPACE}")

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ REGRESS = argm anyold
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+CC = aarch64-linux-gnu-gcc

--- a/debian/control
+++ b/debian/control
@@ -2,26 +2,17 @@ Source: argm
 Section: database
 Priority: optional
 Maintainer: Alexey Bashtanov <alexey@brandwatch.com>
-Build-Depends: debhelper (>= 9), postgresql-server-dev-all (>= 180)
+Build-Depends: debhelper (>= 9), postgresql-server-dev-10:arm64 (>= 10.18-1.pgdg100+1)
 Standards-Version: 3.9.8
 Homepage: https://github.com/BrandwatchLtd/argm
 Vcs-Git: git@github.com:BrandwatchLtd/argm.git
 Vcs-Browser: https://github.com/BrandwatchLtd/argm
 
 Package: postgresql-argm-10
-Architecture: any
+Architecture: arm64
 Depends: postgresql-10, ${shlibs:Depends}, ${misc:Depends}
 Description: argmin and argmax functions
  This PostgreSQL extension proivide several aggregate functions that could be
  used for SQL queries simplification and speedup.
  .
  This package contains the server extension for PostgreSQL 10.
-
-Package: postgresql-argm-13
-Architecture: any
-Depends: postgresql-13, ${shlibs:Depends}, ${misc:Depends}
-Description: argmin and argmax functions
- This PostgreSQL extension proivide several aggregate functions that could be
- used for SQL queries simplification and speedup.
- .
- This package contains the server extension for PostgreSQL 13.

--- a/debian/control.in
+++ b/debian/control.in
@@ -2,14 +2,14 @@ Source: argm
 Section: database
 Priority: optional
 Maintainer: Alexey Bashtanov <alexey@brandwatch.com>
-Build-Depends: debhelper (>= 9), postgresql-server-dev-all (>= 180)
+Build-Depends: debhelper (>= 9), postgresql-server-dev-10:arm64 (>= 10.18-1.pgdg100+1)
 Standards-Version: 3.9.8
 Homepage: https://github.com/BrandwatchLtd/argm
 Vcs-Git: git@github.com:BrandwatchLtd/argm.git
 Vcs-Browser: https://github.com/BrandwatchLtd/argm
 
 Package: postgresql-argm-PGVERSION
-Architecture: any
+Architecture: arm64
 Depends: postgresql-PGVERSION, ${shlibs:Depends}, ${misc:Depends}
 Description: argmin and argmax functions
  This PostgreSQL extension proivide several aggregate functions that could be

--- a/debian/pgversions
+++ b/debian/pgversions
@@ -1,3 +1,2 @@
 # Other versions are not in use
 10
-13

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,9 @@
 # output every command that modifies files on the build system.
 # export DH_VERBOSE = 1
 
+# TODO: set CC in Makefile based on one of these
+DPKG_EXPORT_BUILDFLAGS = 1
+include /usr/share/dpkg/buildflags.mk
 
 # see FEATURE AREAS in dpkg-buildflags(1)
 #export DEB_BUILD_MAINT_OPTIONS = hardening=+all
@@ -22,6 +25,9 @@ override_dh_auto_install:
 
 override_dh_installdocs:
 	dh_installdocs --all README.md
+
+override_dh_auto_clean:
+	+pg_buildext clean postgresql-argm-%v
 
 %:
 	dh $@

--- a/pg_config.minimal
+++ b/pg_config.minimal
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+#
+# Minimal pg_config implementation as replacement for the native pg_config application
+#
+
+case "$1" in
+  --includedir)
+	echo "/usr/include/postgresql"
+	;;
+  --pkgincludedir)
+	echo "/usr/include/postgresql"
+	;;
+  --includedir-server)
+	echo "/usr/include/postgresql/10/server"
+	;;
+  --libdir)
+	echo "/usr/lib/aarch64-linux-gnu/"
+	;;
+  --version)
+	echo "PostgreSQL @POSTGRESQL_VERSION@"
+	;;
+  --configure)
+	echo "@POSTGRESQL_CONF_OPTIONS@"
+	;;
+  --pgxs)
+	echo "/usr/lib/postgresql/10/lib/pgxs/src/makefiles/pgxs.mk"
+	;;
+  --cflags)
+	echo "@TARGET_CFLAGS@"
+	;;
+  --cflags_sl)
+	# defined at src/template/linux
+	echo "-fPIC"
+	;;
+  --cc)
+	echo "@TARGET_CC@"
+	;;
+  --pkglibdir)
+	echo "/usr/lib/postgresql/10/lib"
+	;;
+  --bindir)
+	echo "/usr/lib/postgresql/10/bin"
+	;;
+  --sharedir)
+	echo "/usr/share/postgresql/10"
+	;;
+  --localedir)
+	echo "/usr/share/locale"
+	;;
+  --docdir)
+	echo "/usr/share/doc/postgresql"
+	;;
+  --mandir)
+	echo "/usr/share/postgresql/10/man"
+	;;
+  *)
+	echo "Usage: $0 {OPTION}"
+	echo
+	echo "Options:"
+	echo
+	echo "	--includedir		show location of C header files of the client interfaces"
+	echo "	--pkgincludedir		show location of other C header files"
+	echo "	--includedir-server	show location of C header files for the server"
+	echo "	--libdir		show location of object code libraries"
+	echo "	--version		show the PostgreSQL version"
+	echo "	--configure		show options given to configure script"
+	echo "	--pgxs			show location of extension makefile"
+	echo "	--cflags		show CFLAGS value used when PostgreSQL was built"
+	echo "	--cc			show CC value used when PostgreSQL was built"
+	echo "	--pkglibdir		show location of dynamically loadable modules"
+	echo "	--bindir		show location of user executables"
+	echo "	--sharedir		show location of architecture-independent support files"
+	echo "	--localedir		show location of locale support files"
+	echo "	--docdir		show location of documentation files"
+	echo "	--mandir		show location of manual pages"
+esac


### PR DESCRIPTION
this is not to be merged, as it is very raw:
- it does not build normal amd64 packages, only arm64
- it uses a few nasty kludges
- it builds for Debian Bullseye (12), while bw-sql image and devservers use 9 and 10